### PR TITLE
update all live website links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to www.kitura.io
+# Contributing to www.kitura.dev
 
 Content on this site is licensed under the Apache Licence, Version 2.0.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kitura.io
-This is the GitHub repository for [http://www.kitura.io](http://www.kitura.io), which is hosted as a GitHub pages website.
+This is the GitHub repository for [http://www.kitura.dev](http://www.kitura.dev), which is hosted as a GitHub pages website.
 
 ## Contributing
 We welcome all improvements to this website.  Please see our [Contributing guidelines](CONTRIBUTING.md).

--- a/content/docs/guides/databases/kuery.md
+++ b/content/docs/guides/databases/kuery.md
@@ -13,7 +13,7 @@ title: Add Swift Kuery to your app
 
 We are going to create a new file in our project for the Kuery routes.  The routes defined in this guide are examples of Codable routes. The equivalent definitions for raw routes can be found using the links below each code segment.
 
->If you don't have a server, follow our [Create a server](https://www.kitura.io/docs/getting-started/create-server-cli.html) guide.
+>If you don't have a server, follow our [Create a server](https://www.kitura.dev/docs/getting-started/create-server-cli.html) guide.
 
 Open your `Application.swift` file:
 ```

--- a/content/docs/guides/routing/routing.md
+++ b/content/docs/guides/routing/routing.md
@@ -7,7 +7,7 @@ title: What is routing?
 
 Routing is the way in which requests (the combination of a URL and a HTTP method) are routed to the code that handles them.
 
-When you navigated to [www.kitura.io](https://www.kitura.io) in your browser you were requesting the HTML file that is located there. The server hosting the files will respond with the requested file, if it exists, and you will see the file rendered in your browser. This means that under the covers there’s a server hosting the files for the kitura.io website. In this server there is a route defined that states if we receive a GET request on "/" then respond with the home page.
+When you navigated to [www.kitura.dev](https://www.kitura.dev) in your browser you were requesting the HTML file that is located there. The server hosting the files will respond with the requested file, if it exists, and you will see the file rendered in your browser. This means that under the covers there’s a server hosting the files for the kitura.io website. In this server there is a route defined that states if we receive a GET request on "/" then respond with the home page.
 
 Here we mentioned a GET request being made on "/" but what does that mean? In the next section we will look at GET, which is an HTTP Method, in more detail.
 

--- a/content/web/news/blogs/announcing-kitura-2-5.md
+++ b/content/web/news/blogs/announcing-kitura-2-5.md
@@ -54,7 +54,7 @@ We intend to continue to improve Kitura performance in future.
 
 ##New splash screen
 
-In Kitura 2.5 the default splash screen matches the look and feel of www.kitura.io
+In Kitura 2.5 the default splash screen matches the look and feel of www.kitura.dev
 
 ---
 

--- a/content/web/news/blogs/kitura-swift-server-example.md
+++ b/content/web/news/blogs/kitura-swift-server-example.md
@@ -8,7 +8,7 @@ path: /blogs/kitura-swift-server-example
 
 We have rewritten the [Kitura Sample](https://github.com/Kitura/Kitura-Sample) demo application to better showcase the capabilities of Kitura. This update adds interactive webpages so you can try out the features live. You can also easily view the code for each feature by clicking on the embedded links.
 
-Furthermore, we have added new demos for popular features such as databases, sessions and authentication. Altogether, these changes produce an example app which is a great resource for learning to develop using [Kitura](https://www.kitura.io/).
+Furthermore, we have added new demos for popular features such as databases, sessions and authentication. Altogether, these changes produce an example app which is a great resource for learning to develop using [Kitura](https://www.kitura.dev/).
 
 ![Blog pic 1](../../../images/blogsample1.png)
 

--- a/website/src/components/layout.js
+++ b/website/src/components/layout.js
@@ -26,7 +26,7 @@ const Layout = ({ children }) => {
         <meta name="keywords" content="kitura, microservice, server-side swift, swiftlang" />
         <meta property="og:title" content="Kitura - An Enterprise-Grade Server-Side Swift Web Framework" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://www.kitura.io/" />
+        <meta property="og:url" content="https://www.kitura.dev/" />
         <script src="https://unpkg.com/web-animations-js@2.3.2/web-animations.min.js"></script>
         <script src="https://unpkg.com/muuri@0.8.0/dist/muuri.min.js"></script>
       </Helmet>


### PR DESCRIPTION
This updates all live links to point to the new domain name www.kitura.dev

* Note 1:
There are large number of links still referencing kitura.io that need to remain unchanged as this is still the name of the repo. 
At some time in the future we may want to consider changing the repo name to kitura.dev

* Note 2:
The link to the site on the main page needs to be changed. This will need to be done directly in the repo settings pages.
